### PR TITLE
Better scheduling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version:'2.9.6'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.9.6'
     compile group: 'com.beust', name: 'jcommander', version: jCommanderVersion
-    compile group: 'org.hsqldb', name: 'hsqldb', version:'2.4.0'
+    compile group: 'org.hsqldb', name: 'hsqldb', version:'2.4.1'
     compile group: 'org.springframework', name: 'spring-jdbc', version: '5.0.8.RELEASE'
     compile group: 'commons-dbcp', name: 'commons-dbcp', version: '1.2.2'
     compile group: 'com.google.guava', name: 'guava', version: '23.0'

--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,11 @@ dependencies {
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.9.6'
     compile group: 'com.beust', name: 'jcommander', version: jCommanderVersion
     compile group: 'org.hsqldb', name: 'hsqldb', version:'2.4.0'
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    compile group: 'org.springframework', name: 'spring-jdbc', version: '5.0.8.RELEASE'
     compile group: 'commons-dbcp', name: 'commons-dbcp', version: '1.2.2'
     compile group: 'com.google.guava', name: 'guava', version: '23.0'
+
+    testCompile group: 'junit', name: 'junit', version: '4.12'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     compile group: 'org.hsqldb', name: 'hsqldb', version:'2.4.0'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     compile group: 'commons-dbcp', name: 'commons-dbcp', version: '1.2.2'
+    compile group: 'com.google.guava', name: 'guava', version: '23.0'
 
 }
 

--- a/src/main/java/com/wedevol/xmpp/EntryPoint.java
+++ b/src/main/java/com/wedevol/xmpp/EntryPoint.java
@@ -79,6 +79,12 @@ public class EntryPoint{
         commandLineArgs.dbPass = System.getenv("RADAR_XMPP_DB_PASS") != null ?
                 System.getenv("RADAR_XMPP_DB_PASS") : commandLineArgs.dbPass;
 
+        commandLineArgs.cacheExpiry = System.getenv("RADAR_XMPP_CACHE_EXPIRY") !=null ?
+                Long.valueOf(System.getenv("RADAR_XMPP_CACHE_EXPIRY")) : commandLineArgs.cacheExpiry;
+        commandLineArgs.cacheMaxSize = System.getenv("RADAR_XMPP_CACHE_MAX_SIZE") != null ?
+                Long.valueOf(System.getenv("RADAR_XMPP_CACHE_MAX_SIZE")) : commandLineArgs.cacheMaxSize;
+        commandLineArgs.cacheCleanUpInterval = System.getenv("RADAR_XMPP_CACHE_CLEANUP_INTERVAL") !=null ?
+                Long.valueOf(System.getenv("RADAR_XMPP_CACHE_CLEANUP_INTERVAL")) : commandLineArgs.cacheMaxSize;
 
         if(! commandLineArgs.schedulerType.equals(Config.SCHEDULER_SIMPLE)
                 && (commandLineArgs.dbPath == null || commandLineArgs.dbPath.isEmpty())) {

--- a/src/main/java/com/wedevol/xmpp/EntryPoint.java
+++ b/src/main/java/com/wedevol/xmpp/EntryPoint.java
@@ -49,6 +49,7 @@ public class EntryPoint{
             parser.setProgramName("radar-xmppserver");
             parser.parse(args);
         } catch (ParameterException exc) {
+            exc.printStackTrace();
             parser.usage();
             System.exit(1);
         }
@@ -81,10 +82,12 @@ public class EntryPoint{
 
         commandLineArgs.cacheExpiry = System.getenv("RADAR_XMPP_CACHE_EXPIRY") !=null ?
                 Long.valueOf(System.getenv("RADAR_XMPP_CACHE_EXPIRY")) : commandLineArgs.cacheExpiry;
+
         commandLineArgs.cacheMaxSize = System.getenv("RADAR_XMPP_CACHE_MAX_SIZE") != null ?
                 Long.valueOf(System.getenv("RADAR_XMPP_CACHE_MAX_SIZE")) : commandLineArgs.cacheMaxSize;
+
         commandLineArgs.cacheCleanUpInterval = System.getenv("RADAR_XMPP_CACHE_CLEANUP_INTERVAL") !=null ?
-                Long.valueOf(System.getenv("RADAR_XMPP_CACHE_CLEANUP_INTERVAL")) : commandLineArgs.cacheMaxSize;
+                Long.valueOf(System.getenv("RADAR_XMPP_CACHE_CLEANUP_INTERVAL")) : commandLineArgs.cacheCleanUpInterval;
 
         if(! commandLineArgs.schedulerType.equals(Config.SCHEDULER_SIMPLE)
                 && (commandLineArgs.dbPath == null || commandLineArgs.dbPath.isEmpty())) {

--- a/src/main/java/com/wedevol/xmpp/EntryPoint.java
+++ b/src/main/java/com/wedevol/xmpp/EntryPoint.java
@@ -83,9 +83,6 @@ public class EntryPoint{
         commandLineArgs.cacheExpiry = System.getenv("RADAR_XMPP_CACHE_EXPIRY") !=null ?
                 Long.valueOf(System.getenv("RADAR_XMPP_CACHE_EXPIRY")) : commandLineArgs.cacheExpiry;
 
-        commandLineArgs.cacheMaxSize = System.getenv("RADAR_XMPP_CACHE_MAX_SIZE") != null ?
-                Long.valueOf(System.getenv("RADAR_XMPP_CACHE_MAX_SIZE")) : commandLineArgs.cacheMaxSize;
-
         commandLineArgs.cacheCleanUpInterval = System.getenv("RADAR_XMPP_CACHE_CLEANUP_INTERVAL") !=null ?
                 Long.valueOf(System.getenv("RADAR_XMPP_CACHE_CLEANUP_INTERVAL")) : commandLineArgs.cacheCleanUpInterval;
 

--- a/src/main/java/com/wedevol/xmpp/server/CcsClient.java
+++ b/src/main/java/com/wedevol/xmpp/server/CcsClient.java
@@ -332,9 +332,10 @@ public class CcsClient implements StanzaListener, ReconnectionListener, Connecti
         break;
 
       case Util.BACKEND_ACTION_CANCEL:
+        // TODO test this and re-enable
         String type = inMessage.getDataPayload().get("cancelType");
         // Use a new thread to gain a lock so other threads cannot schedule/cancel while this is cancelling
-        new Thread(() -> {
+    /*        new Thread(() -> {
           if(type.equals("all")) {
             notificationSchedulerService.cancelUsingFcmToken(inMessage.getFrom());
             notificationSchedulerService.cancelUsingCustomId(inMessage.getDataPayload().get("subjectId"));
@@ -346,7 +347,7 @@ public class CcsClient implements StanzaListener, ReconnectionListener, Connecti
             logger.warn("No cancel type provided. Cancelling using the FCM token by default");
             notificationSchedulerService.cancelUsingFcmToken(inMessage.getFrom());
           }
-        }).start();
+        }).start();*/
         break;
 
       case Util.BACKEND_ACTION_UPDATE_TOKEN:

--- a/src/main/java/com/wedevol/xmpp/server/CcsClient.java
+++ b/src/main/java/com/wedevol/xmpp/server/CcsClient.java
@@ -35,7 +35,9 @@ import org.jivesoftware.smack.tcp.XMPPTCPConnectionConfiguration;
 import org.jivesoftware.smackx.ping.PingFailedListener;
 import org.jivesoftware.smackx.ping.PingManager;
 import org.radarcns.xmppserver.factory.SchedulerServiceFactory;
+import org.radarcns.xmppserver.model.Data;
 import org.radarcns.xmppserver.service.NotificationSchedulerService;
+import org.radarcns.xmppserver.util.ScheduleCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmlpull.v1.XmlPullParser;
@@ -72,6 +74,7 @@ public class CcsClient implements StanzaListener, ReconnectionListener, Connecti
   private final Map<String, Message> pendingMessages = new ConcurrentHashMap<>();
 
   private NotificationSchedulerService notificationSchedulerService;
+  private ScheduleCache scheduleCache;
 
   private static CcsClient Instance = null;
 
@@ -100,6 +103,8 @@ public class CcsClient implements StanzaListener, ReconnectionListener, Connecti
 
     this.notificationSchedulerService = SchedulerServiceFactory.getSchedulerService(schedulerType);
     logger.info("Using Scheduler Service of type : {}", this.notificationSchedulerService.getClass().getName());
+
+    scheduleCache = new ScheduleCache(30, 100, this.notificationSchedulerService);
 
   }
 
@@ -314,7 +319,10 @@ public class CcsClient implements StanzaListener, ReconnectionListener, Connecti
         if(!notificationSchedulerService.isRunning()) {
           notificationSchedulerService.start();
         }
-        notificationSchedulerService.schedule(inMessage.getFrom(), inMessage.getDataPayload());
+
+        // TODO Add CacheBuilder and cache requests
+        //notificationSchedulerService.schedule(inMessage.getFrom(), inMessage.getDataPayload());
+          scheduleCache.add(new Data(inMessage.getFrom(), inMessage.getDataPayload()));
         break;
 
       case Util.BACKEND_ACTION_CANCEL:

--- a/src/main/java/com/wedevol/xmpp/server/CcsClient.java
+++ b/src/main/java/com/wedevol/xmpp/server/CcsClient.java
@@ -107,7 +107,7 @@ public class CcsClient implements StanzaListener, ReconnectionListener, Connecti
     logger.info("Using Scheduler Service of type : {}", this.notificationSchedulerService.getClass().getName());
 
     // Remove requests after every 30s or 100 records and schedule them
-    scheduleCache = new ScheduleCache(CommandLineArgs.cacheExpiry, CommandLineArgs.cacheMaxSize, this.notificationSchedulerService);
+    scheduleCache = new ScheduleCache(CommandLineArgs.cacheExpiry, this.notificationSchedulerService);
   }
 
   public static void createInstance(String projectId, String apiKey, boolean debuggable, String schedulerType) {
@@ -277,10 +277,9 @@ public class CcsClient implements StanzaListener, ReconnectionListener, Connecti
         break;
       case "receipt":
         Map<String, String> data = (Map<String, String>) jsonMap.get("data");
-        // TODO: handle the delivery receipt when a device confirms that it received a particular message.
-        logger.info("Message delivered to {} with Original Message Id {} and Data {}", jsonMap.get("from"),
-                data.get("original_message_id"), jsonMap.get("data"));
         // TODO: Send info to kafka and then remove this from the database.
+        notificationSchedulerService.confirmDelivery(data.get("original_message_id"),
+                data.get("device_registration_id"));
         break;
       case "control":
         handleControlMessage(jsonMap);
@@ -328,7 +327,6 @@ public class CcsClient implements StanzaListener, ReconnectionListener, Connecti
           notificationSchedulerService.start();
         }
 
-        // TODO Add CacheBuilder and cache requests
         // notificationSchedulerService.schedule(inMessage.getFrom(), inMessage.getDataPayload());
         scheduleCache.add(new Data(inMessage.getFrom(), inMessage.getDataPayload(), inMessage.getMessageId()));
         break;

--- a/src/main/java/com/wedevol/xmpp/server/CcsClient.java
+++ b/src/main/java/com/wedevol/xmpp/server/CcsClient.java
@@ -276,9 +276,11 @@ public class CcsClient implements StanzaListener, ReconnectionListener, Connecti
         handleNackReceipt(jsonMap);
         break;
       case "receipt":
+        Map<String, String> data = (Map<String, String>) jsonMap.get("data");
         // TODO: handle the delivery receipt when a device confirms that it received a particular message.
-        logger.info("Message delivered to {} with Message Id {} and Data {}", jsonMap.get("from"),
-                jsonMap.get("message_id"), jsonMap.get("data"));
+        logger.info("Message delivered to {} with Original Message Id {} and Data {}", jsonMap.get("from"),
+                data.get("original_message_id"), jsonMap.get("data"));
+        // TODO: Send info to kafka and then remove this from the database.
         break;
       case "control":
         handleControlMessage(jsonMap);

--- a/src/main/java/com/wedevol/xmpp/server/CcsClient.java
+++ b/src/main/java/com/wedevol/xmpp/server/CcsClient.java
@@ -319,7 +319,7 @@ public class CcsClient implements StanzaListener, ReconnectionListener, Connecti
 
       case Util.BACKEND_ACTION_CANCEL:
         String type = inMessage.getDataPayload().get("cancelType");
-        // Use a new thread to gain a lock so other threads cannot schedule while this is cancelling
+        // Use a new thread to gain a lock so other threads cannot schedule/cancel while this is cancelling
         new Thread(() -> {
           if(type.equals("all")) {
             notificationSchedulerService.cancelUsingFcmToken(inMessage.getFrom());

--- a/src/main/java/com/wedevol/xmpp/server/CcsClient.java
+++ b/src/main/java/com/wedevol/xmpp/server/CcsClient.java
@@ -277,6 +277,8 @@ public class CcsClient implements StanzaListener, ReconnectionListener, Connecti
         break;
       case "receipt":
         // TODO: handle the delivery receipt when a device confirms that it received a particular message.
+        logger.info("Message delivered to {} with Message Id {} and Data {}", jsonMap.get("from"),
+                jsonMap.get("message_id"), jsonMap.get("data"));
         break;
       case "control":
         handleControlMessage(jsonMap);
@@ -326,7 +328,7 @@ public class CcsClient implements StanzaListener, ReconnectionListener, Connecti
 
         // TODO Add CacheBuilder and cache requests
         // notificationSchedulerService.schedule(inMessage.getFrom(), inMessage.getDataPayload());
-        scheduleCache.add(new Data(inMessage.getFrom(), inMessage.getDataPayload()));
+        scheduleCache.add(new Data(inMessage.getFrom(), inMessage.getDataPayload(), inMessage.getMessageId()));
         break;
 
       case Util.BACKEND_ACTION_CANCEL:

--- a/src/main/java/org/radarcns/xmppserver/ccs/CcsClientWrapper.java
+++ b/src/main/java/org/radarcns/xmppserver/ccs/CcsClientWrapper.java
@@ -36,6 +36,7 @@ public class CcsClientWrapper {
 
         outMessage.setNotificationPayload(notifyMap);
         outMessage.setTimeToLive(t.getTtlSeconds());
+        outMessage.setDeliveryReceiptRequested(true);
 
         final String jsonRequest = MessageMapper.toJsonString(outMessage);
         ccsClient.sendDownstreamMessage(messageId, jsonRequest);

--- a/src/main/java/org/radarcns/xmppserver/commandline/CommandLineArgs.java
+++ b/src/main/java/org/radarcns/xmppserver/commandline/CommandLineArgs.java
@@ -28,14 +28,11 @@ public class CommandLineArgs {
     @Parameter(names = { "-pa", "--db-password"}, description = "The password to use for db when using database notification schedulers (in-memory and persistent).")
     public static String dbPass = "";
 
-    @Parameter(names = { "-ce", "--cache-expiry"}, description = "The cache expiry in milliseconds to perform time based eviction of records from cache. See CacheBuilder class from Guava library for more details.")
-    public static long cacheExpiry = 30000;
+    @Parameter(names = { "-ce", "--cache-expiry"}, description = "The cache expiry in seconds to perform time based eviction of records from cache.")
+    public static long cacheExpiry = 30;
 
-    @Parameter(names = { "-ci", "--cache-cleanup-interval"}, description = "The cache cleanup interval in milliseconds to perform custom time based eviction of records from cache (In cases where there is not operations on the cache). To increase throughput use a lower value.")
-    public static long cacheCleanUpInterval = 120000;
-
-    @Parameter(names = { "-cs", "--cache-max-size"}, description = "The cache maximum size to perform size based eviction of records from cache. See CacheBuilder class from Guava library for more details.")
-    public static long cacheMaxSize = 1000;
+    @Parameter(names = { "-ci", "--cache-cleanup-interval"}, description = "The cache cleanup interval in seconds to perform custom time based eviction of records from cache (In cases where there is not operations on the cache). To increase throughput use a lower value.")
+    public static long cacheCleanUpInterval = 120;
 
     @Parameter(names = { "-h", "--help"}, help = true, description = "Display the usage of the program with available options.")
     public boolean help;

--- a/src/main/java/org/radarcns/xmppserver/commandline/CommandLineArgs.java
+++ b/src/main/java/org/radarcns/xmppserver/commandline/CommandLineArgs.java
@@ -28,6 +28,15 @@ public class CommandLineArgs {
     @Parameter(names = { "-pa", "--db-password"}, description = "The password to use for db when using database notification schedulers (in-memory and persistent).")
     public static String dbPass = "";
 
+    @Parameter(names = { "-ce", "--cache-expiry"}, description = "The cache expiry in milliseconds to perform time based eviction of records from cache. See CacheBuilder class from Guava library for more details.")
+    public static long cacheExpiry = 30000;
+
+    @Parameter(names = { "-ci", "--cache-cleanup-interval"}, description = "The cache cleanup interval in milliseconds to perform custom time based eviction of records from cache. To increase throughput use a lower value.")
+    public static long cacheCleanUpInterval = 120000;
+
+    @Parameter(names = { "-cs", "--cache-max-size"}, description = "The cache maximum size to perform size based eviction of records from cache. See CacheBuilder class from Guava library for more details.")
+    public static long cacheMaxSize = 1000;
+
     @Parameter(names = { "-h", "--help"}, help = true, description = "Display the usage of the program with available options.")
     public boolean help;
 }

--- a/src/main/java/org/radarcns/xmppserver/commandline/CommandLineArgs.java
+++ b/src/main/java/org/radarcns/xmppserver/commandline/CommandLineArgs.java
@@ -31,7 +31,7 @@ public class CommandLineArgs {
     @Parameter(names = { "-ce", "--cache-expiry"}, description = "The cache expiry in milliseconds to perform time based eviction of records from cache. See CacheBuilder class from Guava library for more details.")
     public static long cacheExpiry = 30000;
 
-    @Parameter(names = { "-ci", "--cache-cleanup-interval"}, description = "The cache cleanup interval in milliseconds to perform custom time based eviction of records from cache. To increase throughput use a lower value.")
+    @Parameter(names = { "-ci", "--cache-cleanup-interval"}, description = "The cache cleanup interval in milliseconds to perform custom time based eviction of records from cache (In cases where there is not operations on the cache). To increase throughput use a lower value.")
     public static long cacheCleanUpInterval = 120000;
 
     @Parameter(names = { "-cs", "--cache-max-size"}, description = "The cache maximum size to perform size based eviction of records from cache. See CacheBuilder class from Guava library for more details.")

--- a/src/main/java/org/radarcns/xmppserver/database/DataSourceWrapper.java
+++ b/src/main/java/org/radarcns/xmppserver/database/DataSourceWrapper.java
@@ -1,0 +1,54 @@
+package org.radarcns.xmppserver.database;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+
+public class DataSourceWrapper {
+
+    private final DataSource dataSource;
+    private static final Logger logger = LoggerFactory.getLogger(DataSourceWrapper.class);
+
+    public DataSourceWrapper(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public void createTableForScheduler() {
+        try {
+            // Create table for db-scheduler
+            dataSource.getConnection().createStatement()
+                    .executeUpdate(
+                            "create table if not exists scheduled_tasks (\n" +
+                                    "  task_name varchar(40) not null,\n" +
+                                    "  task_instance varchar(500) not null,\n" +
+                                    "  task_data blob,\n" +
+                                    "  execution_time timestamp(6) not null,\n" +
+                                    "  picked BOOLEAN not null,\n" +
+                                    "  picked_by varchar(50),\n" +
+                                    "  last_success timestamp(6) null,\n" +
+                                    "  last_failure timestamp(6) null,\n" +
+                                    "  last_heartbeat timestamp(6) null,\n" +
+                                    "  version BIGINT not null,\n" +
+                                    "  PRIMARY KEY (task_name, task_instance)\n" +
+                                    ")");
+
+        } catch (SQLException e) {
+            logger.error("Cannot start the service {} due to {}", this.getClass().getName(), e);
+            e.printStackTrace();
+        }
+    }
+
+    public DataSource getDataSource(){
+        return dataSource;
+    }
+
+    public void close() {
+        try {
+            dataSource.getConnection().close();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/org/radarcns/xmppserver/database/NotificationDatabaseHelper.java
+++ b/src/main/java/org/radarcns/xmppserver/database/NotificationDatabaseHelper.java
@@ -1,0 +1,109 @@
+package org.radarcns.xmppserver.database;
+
+import org.radarcns.xmppserver.model.Notification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+public class NotificationDatabaseHelper {
+
+    private static final Logger logger = LoggerFactory.getLogger(NotificationDatabaseHelper.class);
+    private JdbcTemplate jdbcTemplate;
+
+    public NotificationDatabaseHelper(DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    public void createTableforNotification() {
+        this.jdbcTemplate.execute("create table if not exists notification_info (\n" +
+                "  notification_task_uuid varchar(40),\n" +
+                "  title varchar(100) not null,\n" +
+                "  message BOOLEAN not null,\n" +
+                "  execution_time timestamp(6) null,\n" +
+                "  ttl_seconds BIGINT null,\n" +
+                "  PRIMARY KEY (notification_task_uuid)\n" +
+                ")");
+        logger.debug("Created Table for notification_info");
+    }
+
+    public void createTableForStatus() {
+        this.jdbcTemplate.execute("create table if not exists status_info (\n" +
+                "  subject_id varchar(40) not null,\n" +
+                "  fcm_token varchar(50) not null,\n" +
+                "  notification_task_uuid varchar(40),\n" +
+                "  fcm_message_id varchar(40) UNIQUE,\n" +
+                "  delivered BOOLEAN null,\n" +
+                "  PRIMARY KEY (subject_id, fcm_token, notification_task_uuid),\n" +
+                "  FOREIGN KEY (notification_task_uuid) REFERENCES notification_info(notification_task_uuid)\n" +
+                ")");
+        logger.debug("Created Table for status_info");
+    }
+
+    /**
+     * Finds if a particular notification exists in the database.
+     * @param notification {@link Notification} pojo to compare
+     * @return true if exists, otherwise false
+     */
+    public boolean checkIfNotificationExists(Notification notification) {
+
+        List<Notification> notifications = this.jdbcTemplate.query("select status_info.subject_id, status_info.fcm_token," +
+                        " status_info.notification_task_uuid, notification_info.title, notification_info.ttl_seconds, " +
+                        "notification_info.message, notification_info.execution_time from notification_info inner join status_info" +
+                "where status_info.subject_id = ? and status_info.fcm_token = ?"
+                , new Object[]{notification.getSubjectId(), notification.getRecepient()}
+                , (rs, rowNum) -> new Notification(rs.getString("title"),
+                        rs.getString("message"),
+                        rs.getDate("execution_time"),
+                        rs.getString("subject_id"),
+                        rs.getString("fcm_token"),
+                        rs.getInt("ttl_seconds")));
+        return notifications.contains(notification);
+    }
+
+    public void addNotification(Notification notification, String messageId, String taskId) {
+        int result1 = this.jdbcTemplate.update("insert into notification_info values (?,?,?,?,?)",
+                taskId,
+                notification.getTitle(),
+                notification.getMessage(),
+                notification.getScheduledTime(),
+                notification.getTtlSeconds()
+        );
+        int result2 = this.jdbcTemplate.update("insert into status_info values (?,?,?,?,?)",
+                notification.getSubjectId(),
+                notification.getRecepient(),
+                taskId, messageId, false);
+        if(result1 == 1 && result2 == 1)
+            logger.debug("Added the notification : {}", notification);
+    }
+
+    public void updateDeliveryStatus(boolean status, String fcmToken, String messageId) {
+        int result = this.jdbcTemplate.update("update status_info set delivered = ? where fcm_token = ? and fcm_message_id = ?",
+                status, fcmToken, messageId);
+        if(result == 1)
+            logger.debug("Updated delivery status of message id {} and token {} to {}", messageId, fcmToken, status);
+    }
+
+    public void removeNotification(String taskId) {
+        this.jdbcTemplate.update("delete from status_info where notification_task_uuid = ?", taskId);
+        this.jdbcTemplate.update("delete from notification_info where notification_task_uuid = ?", taskId);
+
+        logger.debug("Removed notification from ");
+    }
+
+    /**
+     * Removes all the notifications for a particular subject and device token.
+     * This follows when a cancel request is made.
+     * //TODO Send delivery info to kafka first before removing them
+     * @param subjectId subject ID to remove
+     * @param fcmToken FCM Token to remove the notifications
+     */
+    public void removeAllNotifications(String subjectId, String fcmToken) {
+        int result = this.jdbcTemplate.update("delete status_info, notification_info from notification_info" +
+                "inner join status_info on notification_info.notification_task_uuid = status_info.notification_task_uuid" +
+                " where status_info.subject_id = ? or status_info.fcm_token = ?", subjectId, fcmToken);
+        logger.debug("{} notifications removed from database for subject={} and token={}", result, subjectId, fcmToken);
+    }
+}

--- a/src/main/java/org/radarcns/xmppserver/database/NotificationDatabaseHelper.java
+++ b/src/main/java/org/radarcns/xmppserver/database/NotificationDatabaseHelper.java
@@ -1,35 +1,48 @@
 package org.radarcns.xmppserver.database;
 
 import org.radarcns.xmppserver.model.Notification;
+import org.radarcns.xmppserver.util.CachedMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import javax.sql.DataSource;
-import java.util.Arrays;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.Temporal;
 import java.util.Date;
 import java.util.List;
 
+
+// TODO add periodic eviction of expired notifications from the database based on the execution_time
 public class NotificationDatabaseHelper {
 
     private static final Logger logger = LoggerFactory.getLogger(NotificationDatabaseHelper.class);
-    private JdbcTemplate jdbcTemplate;
+    private final JdbcTemplate jdbcTemplate;
+    private CachedMap<String, Notification> notificationCachedMap;
 
     public NotificationDatabaseHelper(DataSource dataSource) {
         this.jdbcTemplate = new JdbcTemplate(dataSource);
+
+        // TODO use this cache to improve performance
+        notificationCachedMap = new CachedMap<>(this::findAllNotifications, Notification::getRecepient,
+                Duration.ofSeconds(5), Duration.ofMinutes(30));
     }
 
-
     // TODO change the structure of the tables acc to 3rd Normal form.
+    // i.e - One table for notification which also contains delivery and message id
+    // and the other table will only contain subject_id, fcm_token. This will greatly reduce the number of duplicates
+    // and hence increase the performance.
 
     public void createTableforNotification() {
         this.jdbcTemplate.execute("create table if not exists notification_info (\n" +
                 "  notification_task_uuid varchar(40),\n" +
                 "  title varchar(100) not null,\n" +
                 "  message varchar(100) not null,\n" +
-                "  execution_time varchar(30) null,\n" +
-                "  ttl_seconds BIGINT null,\n" +
-                "  PRIMARY KEY (notification_task_uuid)\n" +
+                "  execution_time varchar(30) not null,\n" +
+                "  ttl_seconds BIGINT,\n" +
+                "  PRIMARY KEY (notification_task_uuid),\n" +
+                "  FOREIGN KEY (notification_task_uuid) REFERENCES status_info(notification_task_uuid) ON DELETE CASCADE\n" +
                 ")");
         logger.debug("Created Table for notification_info");
     }
@@ -38,28 +51,41 @@ public class NotificationDatabaseHelper {
         this.jdbcTemplate.execute("create table if not exists status_info (\n" +
                 "  subject_id varchar(100) not null,\n" +
                 "  fcm_token varchar(256) not null,\n" +
-                "  notification_task_uuid varchar(40),\n" +
-                "  fcm_message_id varchar(100) UNIQUE,\n" +
-                "  delivered BOOLEAN null,\n" +
-                "  PRIMARY KEY (subject_id, fcm_token, notification_task_uuid),\n" +
-                "  FOREIGN KEY (notification_task_uuid) REFERENCES notification_info(notification_task_uuid)\n" +
+                "  notification_task_uuid varchar(40) not null,\n" +
+                "  fcm_message_id varchar(100) not null,\n" +
+                "  delivered BOOLEAN,\n" +
+                "  UNIQUE (notification_task_uuid),\n" +
+                "  UNIQUE (fcm_message_id),\n" +
+                "  PRIMARY KEY (subject_id, fcm_token, notification_task_uuid)\n" +
                 ")");
         logger.debug("Created Table for status_info");
     }
 
     /**
      * Finds if a particular notification exists in the database.
-     * @param notification {@link Notification} pojo to compare
+     * see {@link Notification#equals(Object)} to see the criteria of equality.
+     * @param notification {@link Notification} POJO to compare
      * @return true if exists, otherwise false
      */
     public boolean checkIfNotificationExists(Notification notification) {
+        return findNotifications(notification.getSubjectId(), notification.getRecepient())
+                .contains(notification);
+    }
+
+    /**
+     * Finds notifications for a particular subject from the databse.
+     * @param subjectId the subject Id of the subject
+     * @param fcmToken the FCM token for the device
+     * @return {@link List} of {@link Notification}
+     */
+    private List<Notification> findNotifications(String subjectId, String fcmToken) {
 
         List<Notification> notifications = this.jdbcTemplate.query("select status_info.subject_id, status_info.fcm_token," +
                         " status_info.notification_task_uuid, notification_info.title, notification_info.ttl_seconds," +
                         " notification_info.message, notification_info.execution_time from notification_info inner join status_info" +
                         " on notification_info.notification_task_uuid = status_info.notification_task_uuid where status_info.subject_id = ?" +
                         " and status_info.fcm_token = ?"
-                , new Object[]{notification.getSubjectId(), notification.getRecepient()}
+                , new Object[]{subjectId, fcmToken}
                 , (rs, rowNum) -> new Notification.Builder().setTitle(rs.getString("title"))
                         .setMessage(rs.getString("message"))
                         .setScheduledTime(new Date(Long.parseLong(rs.getString("execution_time"))))
@@ -67,22 +93,45 @@ public class NotificationDatabaseHelper {
                         .setSubjectId(rs.getString("subject_id"))
                         .setTtlSeconds(rs.getInt("ttl_seconds"))
                         .build());
-        logger.debug("Notifications found: {}", Arrays.toString(notifications.toArray()));
-        return notifications.contains(notification);
+
+        return notifications;
+    }
+
+    /**
+     * Finds notifications for a all the subjects from the databse.
+     * @return {@link List} of {@link Notification}
+     */
+    private List<Notification> findAllNotifications() {
+
+        List<Notification> notifications = this.jdbcTemplate.query("select status_info.subject_id, status_info.fcm_token," +
+                        " status_info.notification_task_uuid, notification_info.title, notification_info.ttl_seconds," +
+                        " notification_info.message, notification_info.execution_time from notification_info inner join status_info" +
+                        " on notification_info.notification_task_uuid = status_info.notification_task_uuid"
+                , (rs, rowNum) -> new Notification.Builder().setTitle(rs.getString("title"))
+                        .setMessage(rs.getString("message"))
+                        .setScheduledTime(new Date(Long.parseLong(rs.getString("execution_time"))))
+                        .setRecepient(rs.getString("fcm_token"))
+                        .setSubjectId(rs.getString("subject_id"))
+                        .setTtlSeconds(rs.getInt("ttl_seconds"))
+                        .build());
+
+        return notifications;
     }
 
     public void addNotification(Notification notification, String messageId, String taskId) {
-        int result1 = this.jdbcTemplate.update("insert into notification_info values (?,?,?,?,?)",
+        int result1 = this.jdbcTemplate.update("insert into status_info values (?,?,?,?,?)",
+                notification.getSubjectId(),
+                notification.getRecepient(),
+                taskId, messageId, false);
+
+        int result2 = this.jdbcTemplate.update("insert into notification_info values (?,?,?,?,?)",
                 taskId,
                 notification.getTitle(),
                 notification.getMessage(),
                 String.valueOf(notification.getScheduledTime().toInstant().toEpochMilli()),
                 notification.getTtlSeconds()
         );
-        int result2 = this.jdbcTemplate.update("insert into status_info values (?,?,?,?,?)",
-                notification.getSubjectId(),
-                notification.getRecepient(),
-                taskId, messageId, false);
+
         if(result1 == 1 && result2 == 1)
             logger.debug("Added the notification : {}", notification);
     }
@@ -96,17 +145,20 @@ public class NotificationDatabaseHelper {
 
     public void removeNotification(String taskId) {
         int result = this.jdbcTemplate.update("delete from status_info where notification_task_uuid = ?", taskId);
-        result += this.jdbcTemplate.update("delete from notification_info where notification_task_uuid = ?", taskId);
 
         if(result == 2)
             logger.debug("Removed notification for task id {}", taskId);
     }
 
+    /**
+     * Deletes a notification from both tables as ON DELETE CASCADE is specified.
+     * @param messageId Message Id of the particular notification
+     * @param fcmToken Fcm Token of the device that received/requested the notification
+     */
     public void removeNotification(String messageId, String fcmToken) {
-        int result = this.jdbcTemplate.update("delete from status_info, notification_info from notification_info" +
-                        " inner join status_info on notification_info.notification_task_uuid = status_info.notification_task_uuid" +
-                        " where status_info.fcm_token = ? or status_info.fcm_message_id= ?", fcmToken, messageId);
-        if(result == 1)
+        int result = this.jdbcTemplate.update("delete from status_info" +
+                        " where fcm_token = ? and fcm_message_id = ?", fcmToken, messageId);
+        if(result == 2)
             logger.debug("Removed notification for Message Id {} and Token {}", messageId, fcmToken);
     }
 
@@ -118,9 +170,16 @@ public class NotificationDatabaseHelper {
      * @param fcmToken FCM Token to remove the notifications
      */
     public void removeAllNotifications(String subjectId, String fcmToken) {
-        int result = this.jdbcTemplate.update("delete from status_info, notification_info from notification_info" +
-                " inner join status_info on notification_info.notification_task_uuid = status_info.notification_task_uuid" +
-                " where status_info.subject_id = ? or status_info.fcm_token = ?", subjectId, fcmToken);
-        logger.debug("{} notifications removed from database for subject={} and token={}", result, subjectId, fcmToken);
+        int result = this.jdbcTemplate.update("delete from status_info where" +
+                " subject_id = ? or fcm_token = ?", subjectId, fcmToken);
+        logger.debug("{} notifications removed from database for subject={} and token={}"
+                , result, subjectId, fcmToken);
+    }
+
+    /**
+     * Whether a given temporal threshold is passed, compared to given time.
+     */
+    public static boolean isThresholdPassed(Temporal time, Duration duration) {
+        return Duration.between(time, Instant.now()).compareTo(duration) > 0;
     }
 }

--- a/src/main/java/org/radarcns/xmppserver/model/Data.java
+++ b/src/main/java/org/radarcns/xmppserver/model/Data.java
@@ -10,10 +10,14 @@ import java.util.Map;
  * @author yatharth
  */
 public class Data {
-    // TODO add data fields
 
-    String from;
-    Map<String, String> payload;
+    private String from;
+    private Map<String, String> payload;
+
+    public Data(String from, Map<String, String> payload) {
+        this.from = from;
+        this.payload = payload;
+    }
 
     public String getFrom() {
         return from;

--- a/src/main/java/org/radarcns/xmppserver/model/Data.java
+++ b/src/main/java/org/radarcns/xmppserver/model/Data.java
@@ -1,13 +1,25 @@
 package org.radarcns.xmppserver.model;
 
 
+import java.util.Map;
+
 /**
  *
- * Model class for storing data payload of messages sent downstream.
+ * Model class for storing data payload of messages sent upstream.
  *
  * @author yatharth
  */
 public class Data {
     // TODO add data fields
 
+    String from;
+    Map<String, String> payload;
+
+    public String getFrom() {
+        return from;
+    }
+
+    public Map<String, String> getPayload() {
+        return payload;
+    }
 }

--- a/src/main/java/org/radarcns/xmppserver/model/Data.java
+++ b/src/main/java/org/radarcns/xmppserver/model/Data.java
@@ -1,6 +1,7 @@
 package org.radarcns.xmppserver.model;
 
 
+import java.io.Serializable;
 import java.util.Map;
 
 /**
@@ -9,7 +10,7 @@ import java.util.Map;
  *
  * @author yatharth
  */
-public class Data {
+public class Data implements Serializable{
 
     private String from;
     private Map<String, String> payload;

--- a/src/main/java/org/radarcns/xmppserver/model/Data.java
+++ b/src/main/java/org/radarcns/xmppserver/model/Data.java
@@ -13,11 +13,13 @@ import java.util.Map;
 public class Data implements Serializable{
 
     private String from;
+    private String messageId;
     private Map<String, String> payload;
 
-    public Data(String from, Map<String, String> payload) {
+    public Data(String from, Map<String, String> payload, String messageId) {
         this.from = from;
         this.payload = payload;
+        this.messageId = messageId;
     }
 
     public String getFrom() {
@@ -26,5 +28,9 @@ public class Data implements Serializable{
 
     public Map<String, String> getPayload() {
         return payload;
+    }
+
+    public String getMessageId() {
+        return messageId;
     }
 }

--- a/src/main/java/org/radarcns/xmppserver/model/Notification.java
+++ b/src/main/java/org/radarcns/xmppserver/model/Notification.java
@@ -12,22 +12,21 @@ import java.util.Objects;
  */
 public class Notification implements Serializable{
 
-    private String title;
-    private String message;
-    private String subjectId;
-    private String recepient;
-    private Date scheduledTime;
+    private final String title;
+    private final String message;
+    private final String subjectId;
+    private final String recepient;
+    private final Date scheduledTime;
     // time to live or expiry in seconds
     private int ttlSeconds;
 
-    public Notification(String title, String message, Date date, String recepient,
-                        String subjectId, int ttlSeconds){
-        this.title = title;
-        this.message = message;
-        this.scheduledTime = date;
-        this.recepient = recepient;
-        this.subjectId = subjectId;
-        this.ttlSeconds = ttlSeconds;
+    private Notification(Builder builder){
+        this.title = builder.title;
+        this.message = builder.message;
+        this.scheduledTime = builder.scheduledTime;
+        this.recepient = builder.recepient;
+        this.subjectId = builder.subjectId;
+        this.ttlSeconds = builder.ttlSeconds;
     }
 
     public String getTitle() {
@@ -52,10 +51,6 @@ public class Notification implements Serializable{
 
     public int getTtlSeconds() {
         return ttlSeconds;
-    }
-
-    public void setRecepient(String recepient) {
-        this.recepient = recepient;
     }
 
     @Override
@@ -113,7 +108,66 @@ public class Notification implements Serializable{
 
         Date date = new Date(Long.parseLong(datetime));
 
+        return new Notification.Builder().setTitle(notificationTitle)
+                .setMessage(notificationMessage).setScheduledTime(date).setRecepient(to)
+                .setSubjectId(subjectId).setTtlSeconds(ttlSeconds).build();
+    }
 
-        return new Notification(notificationTitle, notificationMessage, date, to, subjectId, ttlSeconds);
+
+    public static class Builder {
+        private String title;
+        private String message;
+        private String subjectId;
+        private String recepient;
+        private Date scheduledTime;
+        // time to live or expiry in seconds
+        private int ttlSeconds;
+
+        public Builder(){
+            // Do nothing
+        }
+
+        public Builder(Notification notification) {
+            this.title = notification.title;
+            this.message = notification.message;
+            this.scheduledTime = notification.scheduledTime;
+            this.recepient = notification.recepient;
+            this.subjectId = notification.subjectId;
+            this.ttlSeconds = notification.ttlSeconds;
+        }
+
+        public Builder setTitle(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public Builder setMessage(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder setSubjectId(String subjectId) {
+            this.subjectId = subjectId;
+            return this;
+        }
+
+        public Builder setRecepient(String recepient) {
+            this.recepient = recepient;
+            return this;
+        }
+
+        public Builder setScheduledTime(Date scheduledTime) {
+            this.scheduledTime = scheduledTime;
+            return this;
+        }
+
+        public Builder setTtlSeconds(int ttlSeconds) {
+            this.ttlSeconds = ttlSeconds;
+            return this;
+        }
+
+        public Notification build() {
+            return new Notification(this);
+        }
     }
 }

--- a/src/main/java/org/radarcns/xmppserver/model/Notification.java
+++ b/src/main/java/org/radarcns/xmppserver/model/Notification.java
@@ -102,18 +102,18 @@ public class Notification implements Serializable{
         return map;
     }
 
-    public static Notification getNotification(Data data) {
-        String datetime = data.getPayload().get("time"); // epoch timestamp in milliseconds
-        String notificationTitle = data.getPayload().get("notificationTitle");
-        String notificationMessage = data.getPayload().get("notificationMessage");
-        String subjectId = data.getPayload().get("subjectId") == null ? "null" : data.getPayload().get("subjectId");
+    public static Notification getNotification(String to, Map<String, String> payload) {
+        String datetime = payload.get("time"); // epoch timestamp in milliseconds
+        String notificationTitle = payload.get("notificationTitle");
+        String notificationMessage = payload.get("notificationMessage");
+        String subjectId = payload.get("subjectId") == null ? "null" : payload.get("subjectId");
 
         // Set to max of 28 days if not set
-        int ttlSeconds = data.getPayload().get("ttlSeconds") == null ? 2_419_200 : Integer.valueOf(data.getPayload().get("ttlSeconds"));
+        int ttlSeconds = payload.get("ttlSeconds") == null ? 2_419_200 : Integer.valueOf(payload.get("ttlSeconds"));
 
         Date date = new Date(Long.parseLong(datetime));
 
 
-        return new Notification(notificationTitle, notificationMessage, date, data.getFrom(), subjectId, ttlSeconds);
+        return new Notification(notificationTitle, notificationMessage, date, to, subjectId, ttlSeconds);
     }
 }

--- a/src/main/java/org/radarcns/xmppserver/model/Notification.java
+++ b/src/main/java/org/radarcns/xmppserver/model/Notification.java
@@ -102,18 +102,18 @@ public class Notification implements Serializable{
         return map;
     }
 
-    public static Notification getNotification(String to, Map<String, String> payload) {
-        String datetime = payload.get("time"); // epoch timestamp in milliseconds
-        String notificationTitle = payload.get("notificationTitle");
-        String notificationMessage = payload.get("notificationMessage");
-        String subjectId = payload.get("subjectId") == null ? "null" : payload.get("subjectId");
+    public static Notification getNotification(Data data) {
+        String datetime = data.getPayload().get("time"); // epoch timestamp in milliseconds
+        String notificationTitle = data.getPayload().get("notificationTitle");
+        String notificationMessage = data.getPayload().get("notificationMessage");
+        String subjectId = data.getPayload().get("subjectId") == null ? "null" : data.getPayload().get("subjectId");
 
         // Set to max of 28 days if not set
-        int ttlSeconds = payload.get("ttlSeconds") == null ? 2_419_200 : Integer.valueOf(payload.get("ttlSeconds"));
+        int ttlSeconds = data.getPayload().get("ttlSeconds") == null ? 2_419_200 : Integer.valueOf(data.getPayload().get("ttlSeconds"));
 
         Date date = new Date(Long.parseLong(datetime));
 
 
-        return new Notification(notificationTitle, notificationMessage, date, to, subjectId, ttlSeconds);
+        return new Notification(notificationTitle, notificationMessage, date, data.getFrom(), subjectId, ttlSeconds);
     }
 }

--- a/src/main/java/org/radarcns/xmppserver/service/DatabaseNotificationSchedulerService.java
+++ b/src/main/java/org/radarcns/xmppserver/service/DatabaseNotificationSchedulerService.java
@@ -116,13 +116,13 @@ public abstract class DatabaseNotificationSchedulerService implements Notificati
 
     @Override
     public synchronized void schedule(List<Data> data) {
-        data.forEach(s -> schedule(s.getFrom(), s.getPayload()));
+        data.forEach(this::schedule);
     }
 
     @Override
-    public synchronized void schedule(String from, Map<String, String> payload) {
+    public synchronized void schedule(Data data) {
         if(isRunning) {
-            Notification notification = Notification.getNotification(from, payload);
+            Notification notification = Notification.getNotification(data);
 
             // Task id consists of 3 parts -- The FCM token, the subjectID (or any other custom ID)
             // and a UUID to make the task unique

--- a/src/main/java/org/radarcns/xmppserver/service/DatabaseNotificationSchedulerService.java
+++ b/src/main/java/org/radarcns/xmppserver/service/DatabaseNotificationSchedulerService.java
@@ -6,11 +6,13 @@ import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 import org.apache.commons.dbcp.BasicDataSource;
 import org.radarcns.xmppserver.ccs.CcsClientWrapper;
 import org.radarcns.xmppserver.commandline.CommandLineArgs;
+import org.radarcns.xmppserver.model.Data;
 import org.radarcns.xmppserver.model.Notification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -110,6 +112,11 @@ public abstract class DatabaseNotificationSchedulerService implements Notificati
         } else {
             logger.warn("Cannot stop an instance of {} when it is not running.", this.getClass().getName());
         }
+    }
+
+    @Override
+    public synchronized void schedule(List<Data> data) {
+        data.forEach(s -> schedule(s.getFrom(), s.getPayload()));
     }
 
     @Override

--- a/src/main/java/org/radarcns/xmppserver/service/NotificationSchedulerService.java
+++ b/src/main/java/org/radarcns/xmppserver/service/NotificationSchedulerService.java
@@ -11,7 +11,7 @@ public interface NotificationSchedulerService {
 
     void stop();
 
-    void schedule(String from, Map<String, String> payload);
+    void schedule(Data data);
 
     void schedule(List<Data> data);
 

--- a/src/main/java/org/radarcns/xmppserver/service/NotificationSchedulerService.java
+++ b/src/main/java/org/radarcns/xmppserver/service/NotificationSchedulerService.java
@@ -1,5 +1,8 @@
 package org.radarcns.xmppserver.service;
 
+import org.radarcns.xmppserver.model.Data;
+
+import java.util.List;
 import java.util.Map;
 
 public interface NotificationSchedulerService {
@@ -9,6 +12,8 @@ public interface NotificationSchedulerService {
     void stop();
 
     void schedule(String from, Map<String, String> payload);
+
+    void schedule(List<Data> data);
 
     void cancelUsingFcmToken(String from);
 

--- a/src/main/java/org/radarcns/xmppserver/service/NotificationSchedulerService.java
+++ b/src/main/java/org/radarcns/xmppserver/service/NotificationSchedulerService.java
@@ -21,6 +21,8 @@ public interface NotificationSchedulerService {
 
     void updateToken(String oldToken, String newToken);
 
+    void confirmDelivery(String messageId, String token);
+
     boolean isRunning();
 
 }

--- a/src/main/java/org/radarcns/xmppserver/service/SimpleNotificationSchedulerService.java
+++ b/src/main/java/org/radarcns/xmppserver/service/SimpleNotificationSchedulerService.java
@@ -1,5 +1,6 @@
 package org.radarcns.xmppserver.service;
 
+import org.radarcns.xmppserver.model.Data;
 import org.radarcns.xmppserver.model.Notification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,6 +82,11 @@ public class SimpleNotificationSchedulerService implements NotificationScheduler
         } else {
             logger.warn("Cannot schedule using an instance of {} when it is not running.", SimpleNotificationSchedulerService.class.getName());
         }
+    }
+
+    @Override
+    public void schedule(List<Data> data) {
+        data.forEach(s -> schedule(s.getFrom(), s.getPayload()));
     }
 
     @Override

--- a/src/main/java/org/radarcns/xmppserver/service/SimpleNotificationSchedulerService.java
+++ b/src/main/java/org/radarcns/xmppserver/service/SimpleNotificationSchedulerService.java
@@ -104,8 +104,13 @@ public class SimpleNotificationSchedulerService implements NotificationScheduler
     public void updateToken(String oldToken, String newToken) {
         //TODO Add update logic
         if (scheduleTaskHashMap.containsKey(oldToken)) {
-            scheduleTaskHashMap.get(oldToken).forEach(s -> s.getData().setRecepient(newToken));
+            scheduleTaskHashMap.get(oldToken).forEach(s -> s.setData(new Notification.Builder(s.getData()).setRecepient(newToken).build()));
         }
+    }
+
+    @Override
+    public void confirmDelivery(String messageId, String token) {
+        logger.info("Delivered Message with Message ID {} to Token {}", messageId, token);
     }
 
     @Override

--- a/src/main/java/org/radarcns/xmppserver/service/SimpleNotificationSchedulerService.java
+++ b/src/main/java/org/radarcns/xmppserver/service/SimpleNotificationSchedulerService.java
@@ -19,7 +19,7 @@ public class SimpleNotificationSchedulerService implements NotificationScheduler
     private boolean isRunning = false;
 
     private synchronized void scheduleNotificationForDate(Data data) {
-        Notification notification = Notification.getNotification(data);
+        Notification notification = Notification.getNotification(data.getFrom(), data.getPayload());
         ScheduleTask<Notification> notificationScheduleTask = new ScheduleTask<>(notification).scheduleForDate();
 
         logger.info(notification.toString());
@@ -64,7 +64,8 @@ public class SimpleNotificationSchedulerService implements NotificationScheduler
 
     @Override
     public void stop() {
-        if(!isRunning) {
+        if(isRunning) {
+            isRunning = false;
             // Stop all scheduled tasks
             for (String key : scheduleTaskHashMap.keySet()) {
                 scheduleTaskHashMap.get(key).forEach(s -> s.getScheduledFuture().cancel(true));

--- a/src/main/java/org/radarcns/xmppserver/service/SimpleNotificationSchedulerService.java
+++ b/src/main/java/org/radarcns/xmppserver/service/SimpleNotificationSchedulerService.java
@@ -18,21 +18,21 @@ public class SimpleNotificationSchedulerService implements NotificationScheduler
 
     private boolean isRunning = false;
 
-    private synchronized void scheduleNotificationForDate(String from, Map<String, String> payload) {
-        Notification notification = Notification.getNotification(from, payload);
+    private synchronized void scheduleNotificationForDate(Data data) {
+        Notification notification = Notification.getNotification(data);
         ScheduleTask<Notification> notificationScheduleTask = new ScheduleTask<>(notification).scheduleForDate();
 
         logger.info(notification.toString());
 
-        if (scheduleTaskHashMap.containsKey(from)) {
-            if (! scheduleTaskHashMap.get(from).contains(notificationScheduleTask)) {
-                scheduleTaskHashMap.get(from).add(notificationScheduleTask);
+        if (scheduleTaskHashMap.containsKey(data.getFrom())) {
+            if (! scheduleTaskHashMap.get(data.getFrom()).contains(notificationScheduleTask)) {
+                scheduleTaskHashMap.get(data.getFrom()).add(notificationScheduleTask);
             }
         } else {
             HashSet<ScheduleTask<Notification>> newHashSet = new HashSet<>();
             newHashSet.add(notificationScheduleTask);
 
-            scheduleTaskHashMap.put(from + notification.getSubjectId(), newHashSet);
+            scheduleTaskHashMap.put(data.getFrom() + notification.getSubjectId(), newHashSet);
         }
     }
 
@@ -76,9 +76,9 @@ public class SimpleNotificationSchedulerService implements NotificationScheduler
     }
 
     @Override
-    public void schedule(String token, Map<String, String> payload) {
+    public void schedule(Data data) {
         if(isRunning) {
-            scheduleNotificationForDate(token, payload);
+            scheduleNotificationForDate(data);
         } else {
             logger.warn("Cannot schedule using an instance of {} when it is not running.", SimpleNotificationSchedulerService.class.getName());
         }
@@ -86,7 +86,7 @@ public class SimpleNotificationSchedulerService implements NotificationScheduler
 
     @Override
     public void schedule(List<Data> data) {
-        data.forEach(s -> schedule(s.getFrom(), s.getPayload()));
+        data.forEach(this::schedule);
     }
 
     @Override

--- a/src/main/java/org/radarcns/xmppserver/util/CachedMap.java
+++ b/src/main/java/org/radarcns/xmppserver/util/CachedMap.java
@@ -1,0 +1,121 @@
+package org.radarcns.xmppserver.util;
+
+import org.radarcns.xmppserver.database.NotificationDatabaseHelper;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.Temporal;
+import java.util.Collection;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Map that caches the result of a list for a limited time.
+ *
+ * <p>This class is thread-safe if given retriever and key extractors are thread-safe.
+ */
+public class CachedMap<S, T> {
+
+    private final ThrowingSupplier<? extends Collection<T>> retriever;
+    private final Function<T, S> keyExtractor;
+    private final Duration invalidateAfter;
+    private final Duration retryAfter;
+    private Temporal lastFetch;
+    private Map<S, T> cache;
+
+    /**
+     * Map that retrieves data from a supplier and converts that to a map with given key extractor.
+     * Given retriever and key extractor should be thread-safe to make this class thread-safe.
+     *
+     * @param retriever supplier of data.
+     * @param keyExtractor key extractor of individial data points.
+     * @param invalidateAfter invalidate the set of valid results after this duration.
+     * @param retryAfter retry on a missing key after this duration.
+     */
+    public CachedMap(ThrowingSupplier<? extends Collection<T>> retriever,
+                     Function<T, S> keyExtractor, Duration invalidateAfter, Duration retryAfter) {
+        this.retriever = retriever;
+        this.keyExtractor = keyExtractor;
+        this.invalidateAfter = invalidateAfter;
+        this.retryAfter = retryAfter;
+        this.lastFetch = Instant.MIN;
+    }
+
+    /**
+     * Get the cached map, or retrieve a new one if the current one is old.
+     *
+     * @return map of data
+     * @throws IOException if the data could not be retrieved.
+     */
+    public Map<S, T> get() throws IOException {
+        return get(false);
+    }
+
+    /**
+     * Get the cached map, or retrieve a new one if the current one is old.
+     *
+     * @param forceRefresh if true, the cache will be refreshed even if it is recent.
+     * @return map of data
+     * @throws IOException if the data could not be retrieved.
+     */
+    public Map<S, T> get(boolean forceRefresh) throws IOException {
+        if (!forceRefresh) {
+            synchronized (this) {
+                if (cache != null
+                        && !NotificationDatabaseHelper.isThresholdPassed(lastFetch, invalidateAfter)) {
+                    return cache;
+                }
+            }
+        }
+        Map<S, T> result = retriever.get().stream()
+                .collect(Collectors.toMap(keyExtractor, Function.identity()));
+
+        synchronized (this) {
+            cache = result;
+            lastFetch = Instant.now();
+            return cache;
+        }
+    }
+
+    /**
+     * Get a key from the map. If the key is missing, it will check with {@link #mayRetry()} whether
+     * the cache may be updated. If so, it will fetch the cache again and look the key up.
+     *
+     * @param key key of the value to find.
+     * @return element
+     * @throws IOException if the cache cannot be refreshed.
+     * @throws NoSuchElementException if the element is not found.
+     */
+    public T get(S key) throws IOException, NoSuchElementException {
+        T value = get().get(key);
+        if (value == null) {
+            if (mayRetry()) {
+                value = get(true).get(key);
+            }
+            if (value == null) {
+                throw new NoSuchElementException("Cannot find element for key " + key);
+            }
+        }
+        return value;
+    }
+
+    /**
+     * Whether the cache may be refreshed.
+     */
+    public synchronized boolean mayRetry() {
+        return NotificationDatabaseHelper.isThresholdPassed(lastFetch, retryAfter);
+    }
+
+    /**
+     * Supplier that may throw an exception. Otherwise similar to {@link
+     * java.util.function.Supplier}.
+     */
+    @FunctionalInterface
+    public interface ThrowingSupplier<T> {
+
+        T get() throws IOException;
+    }
+}

--- a/src/main/java/org/radarcns/xmppserver/util/ScheduleCache.java
+++ b/src/main/java/org/radarcns/xmppserver/util/ScheduleCache.java
@@ -51,7 +51,8 @@ public class ScheduleCache {
 
     public void add(Data data) {
         logger.info("Adding data to cache...");
-        if(NotificationDatabaseHelper.isThresholdPassed(lastPush, scheduleAfter)) {
+        if(NotificationDatabaseHelper.isThresholdPassed(lastPush, scheduleAfter)
+                && currentData.size() > 10) {
             logger.info("Scheduling all notifications after {} seconds", scheduleAfter);
             synchronized (this) {
                 lastPush = Instant.now();

--- a/src/main/java/org/radarcns/xmppserver/util/ScheduleCache.java
+++ b/src/main/java/org/radarcns/xmppserver/util/ScheduleCache.java
@@ -1,0 +1,42 @@
+package org.radarcns.xmppserver.util;
+
+import com.google.common.cache.*;
+import org.radarcns.xmppserver.model.Data;
+import org.radarcns.xmppserver.service.NotificationSchedulerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+public class ScheduleCache implements RemovalListener<String, Data> {
+
+    private Logger logger = LoggerFactory.getLogger(ScheduleCache.class);
+
+    private Cache<String, Data> dataCache;
+    private NotificationSchedulerService notificationSchedulerService;
+
+    public ScheduleCache(int expiry, int maxSize, NotificationSchedulerService notificationSchedulerService) {
+        dataCache = CacheBuilder.newBuilder()
+                .maximumSize(maxSize)
+                .expireAfterWrite(expiry, TimeUnit.SECONDS)
+                .removalListener(this)
+                .build();
+        this.notificationSchedulerService = notificationSchedulerService;
+    }
+
+    @Override
+    public void onRemoval(@Nonnull RemovalNotification<String, Data> notification) {
+        logger.info("Removing data from cache due to : {}", notification.getCause());
+        notificationSchedulerService.schedule(notification.getValue());
+    }
+
+    public void add(Data data) {
+        logger.info("Adding data to cache...");
+        dataCache.put(data.getFrom()+ UUID.randomUUID(), data);
+    }
+}
+
+
+

--- a/src/main/java/org/radarcns/xmppserver/util/ScheduleCache.java
+++ b/src/main/java/org/radarcns/xmppserver/util/ScheduleCache.java
@@ -8,19 +8,36 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Class for caching incoming schedule requests.
+ * This removes the requests from cache based on time and size.
+ * This is required because the notifications come in bursts and
+ * this helps harmonize them.
+ */
 public class ScheduleCache implements RemovalListener<String, Data> {
 
     private Logger logger = LoggerFactory.getLogger(ScheduleCache.class);
 
-    private Cache<String, Data> dataCache;
-    private NotificationSchedulerService notificationSchedulerService;
+    private final Cache<String, Data> dataCache;
+    private final NotificationSchedulerService notificationSchedulerService;
 
-    public ScheduleCache(int expiry, int maxSize, NotificationSchedulerService notificationSchedulerService) {
+    /**
+     * Creates a time based cache that removes records based on an expiry time
+     * and/or maximum size of the number of records. All the removed records are
+     * passed to the {@link #onRemoval(RemovalNotification)} where they are scheduled.
+     * @param expiry expiry time after which records to be removed from the cache in ms
+     * @param maxSize the maximum size to maintain after which records are removed from the cache
+     * @param notificationSchedulerService the {@link NotificationSchedulerService} to use for scheduling
+     *                                     the notification upon removal of records from the cache
+     */
+    public ScheduleCache(long expiry, long maxSize, NotificationSchedulerService notificationSchedulerService) {
         dataCache = CacheBuilder.newBuilder()
                 .maximumSize(maxSize)
-                .expireAfterWrite(expiry, TimeUnit.SECONDS)
+                .expireAfterWrite(expiry, TimeUnit.MILLISECONDS)
                 .removalListener(this)
                 .build();
         this.notificationSchedulerService = notificationSchedulerService;
@@ -35,6 +52,27 @@ public class ScheduleCache implements RemovalListener<String, Data> {
     public void add(Data data) {
         logger.info("Adding data to cache...");
         dataCache.put(data.getFrom()+ UUID.randomUUID(), data);
+    }
+
+    /**
+     * Clean Up the cache at fixed interval to ensure the values are removed even if there
+     * are no operations (read or write) on the cache.
+     * This stops when the {@link NotificationSchedulerService} is stopped
+     * @param intervalMs The fixed interval at which to clean up cache
+     *
+     */
+    public void runCleanUpTillShutdown(long intervalMs) {
+        final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
+
+        executorService.scheduleAtFixedRate(() -> {
+            if(notificationSchedulerService.isRunning()) {
+                logger.info("Running custom maintenance to evict values every {} mins", (intervalMs/(60*1000)));
+                dataCache.cleanUp();
+            } else {
+                logger.warn("Closing the cache Clean Up thread");
+                executorService.shutdownNow();
+            }
+        }, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
     }
 }
 

--- a/src/main/java/org/radarcns/xmppserver/util/ScheduleCache.java
+++ b/src/main/java/org/radarcns/xmppserver/util/ScheduleCache.java
@@ -77,11 +77,13 @@ public class ScheduleCache {
 
         executorService.scheduleAtFixedRate(() -> {
             if(notificationSchedulerService.isRunning()) {
-                logger.info("Running custom maintenance to evict values every {} mins", (interval/60));
-                synchronized (this) {
-                    lastPush = Instant.now();
-                    notificationSchedulerService.schedule(currentData);
-                    currentData = new ArrayList<>();
+                if(!currentData.isEmpty()) {
+                    logger.info("Running custom maintenance to evict values every {} mins", (interval / 60));
+                    synchronized (this) {
+                        lastPush = Instant.now();
+                        notificationSchedulerService.schedule(currentData);
+                        currentData = new ArrayList<>();
+                    }
                 }
             } else {
                 logger.warn("Closing the cache Clean Up thread");


### PR DESCRIPTION
- Add functionality for scheduling a List<> of notification payloads
- Add a time-based cache for schedule requests
- Add configurable options for cache
- Initial database structure and request delivery receipt
- Intial structure for delivery receipt and builder pattern for notifcations
- Use a separate database to keep track of notifications, tokens, subject Ids, delivery status, etc
- Only schedule a notification if it doesn't already exist.
- Temporarily remove cancel function as it may not be required.
- Some other improvements