### PR TITLE
Persist delivered notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ tmp
 *.tgz
 /dist/
 sqltool
+docker/*.jar
+docker/*.zip
+docker/get-notification-info

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     restart: always
     networks:
       - db
+      - default
     ports:
       - 9001:9001
     volumes:

--- a/src/main/java/com/wedevol/xmpp/EntryPoint.java
+++ b/src/main/java/com/wedevol/xmpp/EntryPoint.java
@@ -97,6 +97,13 @@ public class EntryPoint {
         commandLineArgs.cacheCleanUpInterval = System.getenv("RADAR_XMPP_CACHE_CLEANUP_INTERVAL") != null ?
                 Long.valueOf(System.getenv("RADAR_XMPP_CACHE_CLEANUP_INTERVAL")) : commandLineArgs.cacheCleanUpInterval;
 
+        commandLineArgs.notificationCleanUpinterval = System.getenv("RADAR_XMPP_NOTIFICATION_CLEANUP_INTERVAL") != null ?
+                Long.valueOf(System.getenv("RADAR_XMPP_NOTIFICATION_CLEANUP_INTERVAL")) : commandLineArgs.notificationCleanUpinterval;
+
+        commandLineArgs.notificationExpiry = System.getenv("RADAR_XMPP_NOTIFICATION_EXPIRY") != null ?
+                Long.valueOf(System.getenv("RADAR_XMPP_NOTIFICATION_EXPIRY")) : commandLineArgs.notificationExpiry;
+
+
         if (!commandLineArgs.schedulerType.equals(Config.SCHEDULER_SIMPLE)
                 && (commandLineArgs.dbPath == null || commandLineArgs.dbPath.isEmpty())) {
             switch (commandLineArgs.schedulerType) {

--- a/src/main/java/org/radarcns/xmppserver/commandline/CommandLineArgs.java
+++ b/src/main/java/org/radarcns/xmppserver/commandline/CommandLineArgs.java
@@ -34,6 +34,12 @@ public class CommandLineArgs {
     @Parameter(names = {"-ci", "--cache-cleanup-interval"}, description = "The cache cleanup interval in seconds to perform custom time based eviction of records from cache (In cases where there is not operations on the cache). To increase throughput use a lower value.")
     public static long cacheCleanUpInterval = 120;
 
+    @Parameter(names = {"-ne", "--notification-expiry"}, description = "The notification expiry in days to perform time based eviction of delivered notifications from database. Specified in days.")
+    public static long notificationExpiry = 30;
+
+    @Parameter(names = {"-nc", "--notification-cleanup-interval"}, description = "The notification cleanup interval in days to check for expired delivered notifications. Specified in days.")
+    public static long notificationCleanUpinterval = 1;
+
     @Parameter(names = {"-h", "--help"}, help = true, description = "Display the usage of the program with available options.")
     public boolean help;
 }

--- a/src/main/java/org/radarcns/xmppserver/database/DatabaseCleanupTask.java
+++ b/src/main/java/org/radarcns/xmppserver/database/DatabaseCleanupTask.java
@@ -1,0 +1,7 @@
+package org.radarcns.xmppserver.database;
+
+public interface DatabaseCleanupTask {
+    public void startCleanup();
+
+    public void stopCleanup();
+}

--- a/src/main/java/org/radarcns/xmppserver/database/DefaultDatabaseCleanupTask.java
+++ b/src/main/java/org/radarcns/xmppserver/database/DefaultDatabaseCleanupTask.java
@@ -1,0 +1,55 @@
+package org.radarcns.xmppserver.database;
+
+import org.radarcns.xmppserver.service.CleanupService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class DefaultDatabaseCleanupTask implements DatabaseCleanupTask{
+
+    private final static Logger logger = LoggerFactory.getLogger(DefaultDatabaseCleanupTask.class);
+    private final TimeUnit intervalTimeUnit;
+    private final long interval;
+    private final long expiry;
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private final CleanupService cleanupService;
+
+    /**
+     * Initialise the cleanup thread.
+     * @param intervalTimeUnit TimeUnit to consider for intervalValue to periodically run this thread.
+     * @param intervalValue How often to run this thread. Specified in intervalTimeUnit.
+     * @param expiry How old notifications are considered expired. Should be specified in days.
+     */
+    public DefaultDatabaseCleanupTask(TimeUnit intervalTimeUnit, long intervalValue, long expiry, CleanupService cleanupService) {
+        this.interval = intervalValue;
+        this.expiry = expiry;
+        this.intervalTimeUnit = intervalTimeUnit;
+        this.cleanupService = cleanupService;
+    }
+
+    /**
+     * Starts the first cleanup at 3am from next day and then repeats every {interval} intervalTimeUnits.
+     * Better to provide, this info in day intervals to ensure it always runs in the night (least traffic).
+     */
+    @Override
+    public void startCleanup() {
+        Long nightTime3am = LocalDateTime.now().until(LocalDate.now().plusDays(1).atStartOfDay().plus(Duration.ofHours(3)), ChronoUnit.MINUTES);
+        scheduler.scheduleAtFixedRate(() -> {
+            logger.info("Running Clean Up task to remove delivered notifications");
+            cleanupService.removeNotifications(expiry);
+        }, nightTime3am, interval, intervalTimeUnit);
+    }
+
+    @Override
+    public void stopCleanup() {
+
+    }
+
+}

--- a/src/main/java/org/radarcns/xmppserver/database/DefaultDatabaseCleanupTask.java
+++ b/src/main/java/org/radarcns/xmppserver/database/DefaultDatabaseCleanupTask.java
@@ -12,7 +12,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-public class DefaultDatabaseCleanupTask implements DatabaseCleanupTask{
+public class DefaultDatabaseCleanupTask implements DatabaseCleanupTask {
 
     private final static Logger logger = LoggerFactory.getLogger(DefaultDatabaseCleanupTask.class);
     private final TimeUnit intervalTimeUnit;
@@ -25,12 +25,12 @@ public class DefaultDatabaseCleanupTask implements DatabaseCleanupTask{
 
     /**
      * Initialise the cleanup thread.
-     * @param startTime The milliseconds from now, when to start the cleanup thread.
-     * @param intervalTimeUnit TimeUnit to consider for intervalValue to periodically run this thread.
-     * @param intervalValue How often to run this thread. Specified in intervalTimeUnit.
-     * @param expiry How old notifications are considered expired. Should be specified in days.
-     * @param expiryTimeUnit TimeUnit to consider for expiry
      *
+     * @param startTime        The milliseconds from now, when to start the cleanup thread.
+     * @param intervalTimeUnit TimeUnit to consider for intervalValue to periodically run this thread.
+     * @param intervalValue    How often to run this thread. Specified in intervalTimeUnit.
+     * @param expiry           How old notifications are considered expired. Should be specified in days.
+     * @param expiryTimeUnit   TimeUnit to consider for expiry
      */
     public DefaultDatabaseCleanupTask(long startTime, TimeUnit intervalTimeUnit, long intervalValue, TimeUnit expiryTimeUnit, long expiry, CleanupService cleanupService) {
         this.interval = intervalValue;

--- a/src/main/java/org/radarcns/xmppserver/database/NotificationDatabaseHelper.java
+++ b/src/main/java/org/radarcns/xmppserver/database/NotificationDatabaseHelper.java
@@ -1,5 +1,6 @@
 package org.radarcns.xmppserver.database;
 
+import org.radarcns.xmppserver.model.ExpandedNotification;
 import org.radarcns.xmppserver.model.Notification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,6 +106,23 @@ public class NotificationDatabaseHelper {
         return notifications;
     }
 
+
+    /**
+     * Finds delivered notifications for a all the subjects from the databse.
+     *
+     * @return {@link List} of {@link Notification}
+     */
+    public List<ExpandedNotification> findAllDeliveredNotifications() {
+
+        List<ExpandedNotification> notifications = this.jdbcTemplate.query("select status_info.subject_id, status_info.fcm_token," +
+                        " status_info.notification_task_uuid, status_info.fcm_message_id, status_info.delivered, notification_info.title, notification_info.ttl_seconds," +
+                        " notification_info.message, notification_info.execution_time from notification_info inner join status_info" +
+                        " on notification_info.notification_task_uuid = status_info.notification_task_uuid where status_info.delivered = ?", new Object[]{true}
+                , new ExpandedNotificationRowMapper());
+
+        return notifications;
+    }
+
     public void addNotification(Notification notification, String messageId, String taskId) {
         int result1 = this.jdbcTemplate.update("insert into status_info values (?,?,?,?,?)",
                 notification.getSubjectId(),
@@ -166,6 +184,24 @@ public class NotificationDatabaseHelper {
     }
 
     /**
+     * Removes all the undelivered notifications for a particular subject or device token.
+     * This follows when a cancel request is made.
+     *
+     * @param subjectId subject ID to remove
+     * @param fcmToken  FCM Token to remove the notifications
+     */
+    public void removeAllUndeliveredNotifications(String subjectId, String fcmToken) {
+        int result = this.jdbcTemplate.update("delete from status_info where" +
+                " delivered = ? and (subject_id = ? or fcm_token = ?)", false, subjectId, fcmToken);
+        logger.debug("{} notifications removed from database for subject={} and token={}"
+                , result, subjectId, fcmToken);
+    }
+
+    public void removeDeliveredNotificationsOlderThan(long olderThanMillis) {
+
+    }
+
+    /**
      * Whether a given temporal threshold is passed, compared to given time.
      */
     public static boolean isThresholdPassed(Temporal time, Duration duration) {
@@ -182,6 +218,23 @@ public class NotificationDatabaseHelper {
                     .setRecepient(rs.getString("fcm_token"))
                     .setSubjectId(rs.getString("subject_id"))
                     .setTtlSeconds(rs.getInt("ttl_seconds"))
+                    .build();
+        }
+    }
+
+    private class ExpandedNotificationRowMapper implements RowMapper<ExpandedNotification> {
+        @Override
+        public ExpandedNotification mapRow(ResultSet rs, int rowNum) throws SQLException {
+            return new ExpandedNotification.Builder(new Notification.Builder().setTitle(rs.getString("title"))
+                    .setMessage(rs.getString("message"))
+                    .setScheduledTime(new Date(Long.parseLong(rs.getString("execution_time"))))
+                    .setRecepient(rs.getString("fcm_token"))
+                    .setSubjectId(rs.getString("subject_id"))
+                    .setTtlSeconds(rs.getInt("ttl_seconds"))
+                    .build())
+                    .delivered(rs.getBoolean("delivered"))
+                    .fcmMessageId("fcm_message_id")
+                    .notificationTaskUuid("notification_task_uuid")
                     .build();
         }
     }

--- a/src/main/java/org/radarcns/xmppserver/database/NotificationDatabaseHelper.java
+++ b/src/main/java/org/radarcns/xmppserver/database/NotificationDatabaseHelper.java
@@ -108,7 +108,7 @@ public class NotificationDatabaseHelper {
 
 
     /**
-     * Finds delivered notifications for a all the subjects from the databse.
+     * Finds delivered notifications for all the subjects from the databse.
      *
      * @return {@link List} of {@link Notification}
      */

--- a/src/main/java/org/radarcns/xmppserver/database/NotificationDatabaseHelper.java
+++ b/src/main/java/org/radarcns/xmppserver/database/NotificationDatabaseHelper.java
@@ -72,7 +72,7 @@ public class NotificationDatabaseHelper {
     }
 
     /**
-     * Finds notifications for a particular subject from the databse.
+     * Finds undelivered notifications for a particular subject from the database.
      *
      * @param subjectId the subject Id of the subject
      * @param fcmToken  the FCM token for the device
@@ -84,8 +84,8 @@ public class NotificationDatabaseHelper {
                         " status_info.notification_task_uuid, notification_info.title, notification_info.ttl_seconds," +
                         " notification_info.message, notification_info.execution_time from notification_info inner join status_info" +
                         " on notification_info.notification_task_uuid = status_info.notification_task_uuid where status_info.subject_id = ?" +
-                        " and status_info.fcm_token = ?"
-                , new Object[]{subjectId, fcmToken}, new NotificationRowMapper());
+                        " and status_info.fcm_token = ? and status_info.delivered = ?"
+                , new Object[]{subjectId, fcmToken, false}, new NotificationRowMapper());
 
         return notifications;
     }
@@ -233,8 +233,8 @@ public class NotificationDatabaseHelper {
                     .setTtlSeconds(rs.getInt("ttl_seconds"))
                     .build())
                     .delivered(rs.getBoolean("delivered"))
-                    .fcmMessageId("fcm_message_id")
-                    .notificationTaskUuid("notification_task_uuid")
+                    .fcmMessageId(rs.getString("fcm_message_id"))
+                    .notificationTaskUuid(rs.getString("notification_task_uuid"))
                     .build();
         }
     }

--- a/src/main/java/org/radarcns/xmppserver/model/ExpandedNotification.java
+++ b/src/main/java/org/radarcns/xmppserver/model/ExpandedNotification.java
@@ -59,4 +59,14 @@ public class ExpandedNotification {
             return new ExpandedNotification(this);
         }
     }
+
+    @Override
+    public String toString() {
+        return "ExpandedNotification{" +
+                "notificationTaskUuid='" + notificationTaskUuid + '\'' +
+                ", delivered=" + delivered +
+                ", fcmMessageId='" + fcmMessageId + '\'' +
+                ", notification=" + notification +
+                '}';
+    }
 }

--- a/src/main/java/org/radarcns/xmppserver/model/ExpandedNotification.java
+++ b/src/main/java/org/radarcns/xmppserver/model/ExpandedNotification.java
@@ -1,0 +1,62 @@
+package org.radarcns.xmppserver.model;
+
+public class ExpandedNotification {
+
+    private String notificationTaskUuid;
+    private boolean delivered;
+    private String fcmMessageId;
+    private Notification notification;
+
+    public String getNotificationTaskUuid() {
+        return notificationTaskUuid;
+    }
+
+    public boolean isDelivered() {
+        return delivered;
+    }
+
+    public String getFcmMessageId() {
+        return fcmMessageId;
+    }
+
+    public Notification getNotification() {
+        return notification;
+    }
+
+    private ExpandedNotification(Builder builder) {
+        this.notificationTaskUuid = builder.notificationTaskUuid;
+        this.delivered = builder.delivered;
+        this.fcmMessageId = builder.fcmMessageId;
+        this.notification = builder.notification;
+    }
+
+    public static class Builder {
+        private String notificationTaskUuid;
+        private boolean delivered;
+        private String fcmMessageId;
+        private Notification notification;
+
+        public Builder(Notification notification) {
+            this.notification = notification;
+        }
+
+        public Builder delivered(boolean delivered) {
+            this.delivered = delivered;
+            return this;
+        }
+
+        public Builder notificationTaskUuid(String notificationTaskUuid) {
+            this.notificationTaskUuid = notificationTaskUuid;
+            return this;
+        }
+
+        public Builder fcmMessageId(String fcmMessageId) {
+            this.fcmMessageId = fcmMessageId;
+            return this;
+        }
+
+        public ExpandedNotification build() {
+            return new ExpandedNotification(this);
+        }
+    }
+}

--- a/src/main/java/org/radarcns/xmppserver/service/CleanupService.java
+++ b/src/main/java/org/radarcns/xmppserver/service/CleanupService.java
@@ -1,5 +1,7 @@
 package org.radarcns.xmppserver.service;
 
+import java.util.concurrent.TimeUnit;
+
 public interface CleanupService {
-    void removeNotifications(long expiry);
+    void removeNotifications(TimeUnit expiryTimeUnit, long expiry);
 }

--- a/src/main/java/org/radarcns/xmppserver/service/CleanupService.java
+++ b/src/main/java/org/radarcns/xmppserver/service/CleanupService.java
@@ -1,0 +1,5 @@
+package org.radarcns.xmppserver.service;
+
+public interface CleanupService {
+    void removeNotifications(long expiry);
+}

--- a/src/main/java/org/radarcns/xmppserver/service/DatabaseCleanupService.java
+++ b/src/main/java/org/radarcns/xmppserver/service/DatabaseCleanupService.java
@@ -2,6 +2,7 @@ package org.radarcns.xmppserver.service;
 
 import org.radarcns.xmppserver.database.NotificationDatabaseHelper;
 import org.radarcns.xmppserver.model.ExpandedNotification;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
@@ -13,7 +14,7 @@ import java.util.concurrent.TimeUnit;
 public class DatabaseCleanupService implements CleanupService {
 
     private NotificationDatabaseHelper notificationDatabaseHelper;
-    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(DatabaseCleanupService.class);
+    private static final Logger logger = LoggerFactory.getLogger(DatabaseCleanupService.class);
 
     DatabaseCleanupService(NotificationDatabaseHelper notificationDatabaseHelper) {
         this.notificationDatabaseHelper = notificationDatabaseHelper;

--- a/src/main/java/org/radarcns/xmppserver/service/DatabaseCleanupService.java
+++ b/src/main/java/org/radarcns/xmppserver/service/DatabaseCleanupService.java
@@ -1,0 +1,31 @@
+package org.radarcns.xmppserver.service;
+
+import org.radarcns.xmppserver.database.NotificationDatabaseHelper;
+import org.radarcns.xmppserver.model.ExpandedNotification;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+public class DatabaseCleanupService implements CleanupService {
+
+    private NotificationDatabaseHelper notificationDatabaseHelper;
+
+    public DatabaseCleanupService(NotificationDatabaseHelper notificationDatabaseHelper) {
+        this.notificationDatabaseHelper = notificationDatabaseHelper;
+    }
+
+    @Override
+    public synchronized void removeNotifications(long expiry) {
+        long millisToCompare = new Date().toInstant().toEpochMilli() - Duration.ofDays(expiry).toMillis();
+
+        Set<ExpandedNotification> notificationSet = Collections.synchronizedSet(
+                new HashSet<>(notificationDatabaseHelper.findAllDeliveredNotifications()));
+
+        notificationSet.stream()
+                .filter(n -> n.getNotification().getScheduledTime().toInstant().toEpochMilli() < millisToCompare)
+                .forEach(n -> notificationDatabaseHelper.removeNotification(n.getNotificationTaskUuid()));
+    }
+}

--- a/src/main/java/org/radarcns/xmppserver/service/DatabaseCleanupService.java
+++ b/src/main/java/org/radarcns/xmppserver/service/DatabaseCleanupService.java
@@ -2,30 +2,36 @@ package org.radarcns.xmppserver.service;
 
 import org.radarcns.xmppserver.database.NotificationDatabaseHelper;
 import org.radarcns.xmppserver.model.ExpandedNotification;
+import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 public class DatabaseCleanupService implements CleanupService {
 
     private NotificationDatabaseHelper notificationDatabaseHelper;
+    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(DatabaseCleanupService.class);
 
-    public DatabaseCleanupService(NotificationDatabaseHelper notificationDatabaseHelper) {
+    DatabaseCleanupService(NotificationDatabaseHelper notificationDatabaseHelper) {
         this.notificationDatabaseHelper = notificationDatabaseHelper;
     }
 
     @Override
-    public synchronized void removeNotifications(long expiry) {
-        long millisToCompare = new Date().toInstant().toEpochMilli() - Duration.ofDays(expiry).toMillis();
+    public synchronized void removeNotifications(TimeUnit expiryTimeUnit, long expiry) {
+        long millisToCompare = new Date().toInstant().toEpochMilli() - expiryTimeUnit.toMillis(expiry);
 
         Set<ExpandedNotification> notificationSet = Collections.synchronizedSet(
                 new HashSet<>(notificationDatabaseHelper.findAllDeliveredNotifications()));
 
+        logger.debug("Delivered Notifications:" + notificationSet);
+
         notificationSet.stream()
                 .filter(n -> n.getNotification().getScheduledTime().toInstant().toEpochMilli() < millisToCompare)
                 .forEach(n -> notificationDatabaseHelper.removeNotification(n.getNotificationTaskUuid()));
+
+        logger.info("Delivered Notifications removed!");
     }
 }

--- a/src/main/java/org/radarcns/xmppserver/service/DatabaseNotificationSchedulerService.java
+++ b/src/main/java/org/radarcns/xmppserver/service/DatabaseNotificationSchedulerService.java
@@ -28,10 +28,11 @@ import java.util.stream.Collectors;
 
 /**
  * Database notification scheduler service class for the XMPP Server
- * This has functionality for both in-memory and persisent data bases.
+ * This has functionality for both in-memory, persisent and server data bases.
  * Abstract class so has to instantiated through sub-classes. Look at
- * {@link InMemoryDatabaseNotificationSchedulerService} and
- * {@link PersistentDatabaseNotificationSchedulerService}
+ * {@link InMemoryDatabaseNotificationSchedulerService},
+ * {@link PersistentDatabaseNotificationSchedulerService} and
+ * {@link ServerDatabaseNotificationSchedulerService}
  *
  * @author yatharthranjan
  */

--- a/src/main/java/org/radarcns/xmppserver/service/DatabaseNotificationSchedulerService.java
+++ b/src/main/java/org/radarcns/xmppserver/service/DatabaseNotificationSchedulerService.java
@@ -70,8 +70,8 @@ public abstract class DatabaseNotificationSchedulerService implements Notificati
 
         long nightTime3am = LocalDateTime.now().until(LocalDate.now().plusDays(1).atStartOfDay().plus(Duration.ofHours(3)), ChronoUnit.MINUTES);
         // Clean the DB every day looking for delivered notifications older than 30 days
-        databaseCleanupTask = new DefaultDatabaseCleanupTask(nightTime3am, TimeUnit.DAYS, 1,
-                TimeUnit.DAYS, 30, new DatabaseCleanupService(databaseHelper));
+        databaseCleanupTask = new DefaultDatabaseCleanupTask(nightTime3am, TimeUnit.DAYS, CommandLineArgs.notificationCleanUpinterval,
+                TimeUnit.DAYS, CommandLineArgs.notificationExpiry, new DatabaseCleanupService(databaseHelper));
     }
 
     @Override

--- a/src/main/java/org/radarcns/xmppserver/service/DatabaseNotificationSchedulerService.java
+++ b/src/main/java/org/radarcns/xmppserver/service/DatabaseNotificationSchedulerService.java
@@ -218,7 +218,7 @@ public abstract class DatabaseNotificationSchedulerService implements Notificati
                     scheduler.cancel(taskScheduledExecution.getTaskInstance());
                 }
             });
-            databaseHelper.removeAllNotifications(null, from);
+            databaseHelper.removeAllUndeliveredNotifications(null, from);
         } else {
             logger.warn("Cannot cancelUsingFcmToken using an instance of {} when it is not running. Please start the service first.", this.getClass().getName());
         }
@@ -235,7 +235,7 @@ public abstract class DatabaseNotificationSchedulerService implements Notificati
                     scheduler.cancel(taskScheduledExecution.getTaskInstance());
                 }
             });
-            databaseHelper.removeAllNotifications(id, null);
+            databaseHelper.removeAllUndeliveredNotifications(id, null);
         } else {
             logger.warn("Cannot cancelUsingFcmToken using an instance of {} when it is not running. Please start the service first.", this.getClass().getName());
         }
@@ -275,11 +275,11 @@ public abstract class DatabaseNotificationSchedulerService implements Notificati
     @Override
     public void confirmDelivery(String messageId, String token) {
         // TODO: Uncomment so kafka sender can pick this up from the Database
-        //databaseHelper.updateDeliveryStatus(true, token, messageId);
+        databaseHelper.updateDeliveryStatus(true, token, messageId);
 
         // TODO: remove this and add in the Batched Kafka Sender
-        databaseHelper.removeNotification(messageId, token);
-        logger.info("Removed message from database after delivery: {} ", messageId);
+        //databaseHelper.removeNotification(messageId, token);
+        logger.info("Updated delivery status: {} ", messageId);
     }
 
     @Override


### PR DESCRIPTION
- Persists the notifications in the database after delivery flagging them as delivered
- This runs a thread to check for the expiry of the delivered notifications and remove them from the database (default is checking every day and removing delivered notifications older than 30 days)
- The same interface (`CleanupService.java`) can be implemented again in future work for removing notifications and sending to kafka.
Closes #16 