### PR TITLE
Fix disconnection

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The following changes have been introduced -
 9. As seen above the options can be either set as command line args or as environment variables. The docker image is also published on Docker hub [radarbase/radar-xmppserver](https://hub.docker.com/r/radarbase/fcmxmppserverv2/).
    Also make sure to mount the path of the db as a bind mount to host if using a persistent db otherwise all data will be lost if the container is removed.
 10. Examples of docker-compose builds are included in the `/docker` directory along with a Dockerfile for building and running hsql server in a docker container. These can be used for development or modified for production deployments.
+11. By default, the application logs all messages to file at the path `/usr/local/radar/xmpp-server/logs/`, please make sure to mount your host path to this path to persist the log files. This creates separate rotating files base on time for DEBUG level(and higher, means including all messages except TRACE) and ERROR level(and higher).
 
 # Old README from base
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ ext {
 }
 
 repositories {
-        
+
      maven { url "http://repo.maven.apache.org/maven2" }
 }
 dependencies {
@@ -39,10 +39,10 @@ dependencies {
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: jacksonVersion
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
     compile group: 'com.beust', name: 'jcommander', version: jCommanderVersion
-    compile group: 'org.hsqldb', name: 'hsqldb', version: hsqlVersion
     compile group: 'org.springframework', name: 'spring-jdbc', version: springVersion
     compile group: 'commons-dbcp', name: 'commons-dbcp', version: commonsDbcpVersion
     runtimeOnly group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion
+    runtimeOnly group: 'org.hsqldb', name: 'hsqldb', version: hsqlVersion
 
     testCompile group: 'junit', name: 'junit', version: junitVersion
 

--- a/src/main/java/org/radarcns/xmppserver/model/Notification.java
+++ b/src/main/java/org/radarcns/xmppserver/model/Notification.java
@@ -15,6 +15,7 @@ import java.util.Objects;
  * @author yatharthranjan
  */
 public class Notification implements Serializable {
+    private static final long serialVersionUID = 3284965300642907379L;
 
     private final String title;
     private final String message;

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -14,7 +14,7 @@
 		class="ch.qos.logback.core.rolling.RollingFileAppender">
 		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
 			<fileNamePattern>/usr/local/radar/xmpp-server/logs/xmpp-server-%d{yyyy-MM-dd}.log</fileNamePattern>
-			<maxHistory>7</maxHistory>
+			<maxHistory>30</maxHistory>
 			<totalSizeCap>3GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
@@ -26,7 +26,7 @@
 			  class="ch.qos.logback.core.rolling.RollingFileAppender">
 		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
 			<fileNamePattern>/usr/local/radar/xmpp-server/logs/xmpp-server-error-%d{yyyy-MM-dd}.log</fileNamePattern>
-			<maxHistory>7</maxHistory>
+			<maxHistory>60</maxHistory>
 			<totalSizeCap>3GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>


### PR DESCRIPTION
- The FCM server sends disconnection requests once in a while (according to docs this is for periodic maintenance, cleaning of stale connections, etc). When this occurs the connection needs to be closed and connected again.
- The smack library sends a `presence unavailable` (`<presence id='tMZDi-119397' type='unavailable'></presence>`) message and closes the connection when such a request is received from the server as mentioned in the java docs in this PR.
- This PR adds an interceptor to intercept the presence message and issue a reconnection.

- This also increases the log retention from 7 days to 30 days for normal level logs and 60 days for error logs.